### PR TITLE
Don't send nick with link titles

### DIFF
--- a/src/config/strings.js
+++ b/src/config/strings.js
@@ -48,7 +48,7 @@ export default {
             overview: "Gets titles from URLs."
         },
 
-        title: "<{sender}> {msg}",
+        title: "{msg}",
         image: "{height}x{width} {type} {humanSize}",
         mp4: "video/mp4: {duration}, {dimensions}, {fileSize}"
     },


### PR DESCRIPTION
Presumably the sender knows what they are linking to. No need to
highlight them when dropping the title.
